### PR TITLE
feat: add shieldtelegram module for Telegram Bot Login

### DIFF
--- a/shieldtelegram/README.md
+++ b/shieldtelegram/README.md
@@ -1,0 +1,225 @@
+# shieldtelegram
+
+Telegram Bot Login authentication for Shield framework.
+
+## Overview
+
+`shieldtelegram` implements Telegram's Bot Login (Login with Telegram) authentication flow. Unlike standard OAuth2 flows, Telegram uses a widget-based approach where authentication data is returned as URL hash parameters and verified using HMAC-SHA256.
+
+## Features
+
+- ✅ HMAC-SHA256 signature verification
+- ✅ Telegram Login Widget generation
+- ✅ HTTP handler for processing callbacks
+- ✅ Configurable authentication data age validation
+- ✅ Multiple input formats (query params, form data, JSON)
+
+## Installation
+
+```bash
+go get go.inout.gg/shield/shieldtelegram
+```
+
+## Quick Start
+
+### 1. Create a Telegram Bot
+
+First, create a bot with [@BotFather](https://t.me/botfather) on Telegram and obtain:
+- Bot token (e.g., `123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ`)
+- Bot username (e.g., `my_auth_bot`)
+
+### 2. Set up the Provider
+
+```go
+import "go.inout.gg/shield/shieldtelegram"
+
+provider := shieldtelegram.NewProvider(&shieldtelegram.Config{
+    BotToken:    "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    BotUsername: "my_auth_bot",
+    MaxAuthAge:  24 * time.Hour, // Optional, defaults to 24h
+})
+```
+
+### 3. Generate the Login Widget
+
+```go
+http.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+    radius := 10
+    widget := provider.GenerateWidget(
+        "https://yoursite.com/auth/telegram/callback",
+        &shieldtelegram.WidgetOptions{
+            Size:          "large",
+            RequestAccess: true,
+            Radius:        &radius,
+            UsePic:        true,
+            Lang:          "en",
+        },
+    )
+
+    // Render the widget in your HTML
+    fmt.Fprintf(w, `
+        <html>
+        <body>
+            <h1>Login with Telegram</h1>
+            %s
+            %s
+        </body>
+        </html>
+    `, widget, shieldtelegram.GenerateWidgetCallback("/api/auth/telegram"))
+})
+```
+
+### 4. Handle the Callback
+
+```go
+http.HandleFunc("/api/auth/telegram", func(w http.ResponseWriter, r *http.Request) {
+    userInfo, err := shieldtelegram.HandleCallback(r.Context(), r, provider)
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusUnauthorized)
+        return
+    }
+
+    // userInfo contains validated user data:
+    // - userInfo.ID (Telegram user ID)
+    // - userInfo.FirstName
+    // - userInfo.LastName
+    // - userInfo.Username
+    // - userInfo.PhotoURL
+    // - userInfo.AuthDate
+
+    // Create session, set cookies, etc.
+    // ...
+})
+```
+
+## How It Works
+
+### Authentication Flow
+
+1. User clicks the Telegram Login Widget on your website
+2. User is redirected to Telegram (app or web)
+3. User authorizes your bot
+4. Telegram redirects back with authentication data in URL hash
+5. JavaScript extracts the data and sends it to your server
+6. Server validates the HMAC-SHA256 signature
+7. Server creates a session for the authenticated user
+
+### Security
+
+The package implements Telegram's security specification:
+
+1. **Data Integrity**: All authentication data is signed with HMAC-SHA256 using your bot token
+2. **Freshness**: Authentication data age is validated (configurable, default 24 hours)
+3. **Authenticity**: The hash is verified against the data-check-string
+
+The verification process:
+```
+data-check-string = "auth_date=<timestamp>\nfirst_name=<name>\n..."
+secret_key = SHA256(bot_token)
+hash = HMAC-SHA256(data-check-string, secret_key)
+```
+
+## API Reference
+
+### Types
+
+#### `Config`
+```go
+type Config struct {
+    BotToken    string        // Bot token from BotFather
+    BotUsername string        // Bot username (without @)
+    MaxAuthAge  time.Duration // Max age of auth data (default: 24h)
+}
+```
+
+#### `AuthData`
+```go
+type AuthData struct {
+    ID        int64  // Telegram user ID
+    FirstName string // User's first name
+    LastName  string // User's last name (optional)
+    Username  string // User's username (optional)
+    PhotoURL  string // Profile photo URL (optional)
+    AuthDate  int64  // Unix timestamp
+    Hash      string // HMAC-SHA256 signature
+}
+```
+
+#### `UserInfo`
+```go
+type UserInfo struct {
+    ID        int64
+    FirstName string
+    LastName  string
+    Username  string
+    PhotoURL  string
+    AuthDate  time.Time
+}
+```
+
+#### `WidgetOptions`
+```go
+type WidgetOptions struct {
+    Size          string // "large", "medium", or "small"
+    RequestAccess bool   // Request permission to message user
+    Radius        *int   // Border radius (0-20)
+    UsePic        bool   // Show user photo in button
+    Lang          string // Widget language (default: "en")
+}
+```
+
+### Functions
+
+#### `NewProvider(cfg *Config) Provider`
+Creates a new Telegram Login provider.
+
+#### `HandleCallback(ctx context.Context, r *http.Request, provider Provider) (*UserInfo, error)`
+Processes the Telegram login callback and returns validated user information.
+
+#### `GenerateWidgetCallback(serverCallbackURL string) string`
+Generates JavaScript code to extract auth data from URL hash and send it to your server.
+
+### Provider Interface
+
+```go
+type Provider interface {
+    Verify(ctx context.Context, data *AuthData) (*UserInfo, error)
+    GenerateWidget(redirectURL string, opts *WidgetOptions) string
+}
+```
+
+## Error Handling
+
+The package defines the following errors:
+
+- `ErrInvalidHash`: Authentication hash verification failed
+- `ErrAuthExpired`: Authentication data is too old
+- `ErrMissingAuthData`: Required authentication data is missing
+
+## Integration with Shield
+
+This package follows Shield's modular architecture and can be integrated alongside other authentication methods:
+
+```go
+// Combine with password authentication
+passwordProvider := shieldpassword.NewProvider(...)
+telegramProvider := shieldtelegram.NewProvider(...)
+
+// Use both in your auth flow
+```
+
+## Testing
+
+Run tests:
+```bash
+go test ./shieldtelegram/...
+```
+
+## References
+
+- [Telegram Login Widget Documentation](https://core.telegram.org/widgets/login)
+- [Telegram Bot API](https://core.telegram.org/bots/api)
+
+## License
+
+MIT License (same as Shield framework)

--- a/shieldtelegram/example_test.go
+++ b/shieldtelegram/example_test.go
@@ -1,0 +1,108 @@
+package shieldtelegram_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.inout.gg/shield/shieldtelegram"
+)
+
+// Example of setting up a Telegram login provider.
+func ExampleNewProvider() {
+	provider := shieldtelegram.NewProvider(&shieldtelegram.Config{
+		BotToken:   "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+		MaxAuthAge: 24 * time.Hour,
+	})
+
+	fmt.Printf("Provider created: %T\n", provider)
+	// Output: Provider created: *shieldtelegram.provider
+}
+
+// Example of handling a Telegram login callback.
+func ExampleHandleCallback() {
+	provider := shieldtelegram.NewProvider(&shieldtelegram.Config{
+		BotToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+	})
+
+	// Simulate an HTTP request with Telegram auth data
+	req, _ := http.NewRequest("GET", "/auth/telegram/callback?id=123456789&first_name=John&auth_date=1234567890&hash=abc123", nil)
+
+	userInfo, err := shieldtelegram.HandleCallback(context.Background(), req, provider)
+	if err != nil {
+		fmt.Printf("Authentication failed: %v\n", err)
+		return
+	}
+
+	fmt.Printf("User ID: %d, Name: %s\n", userInfo.ID, userInfo.FirstName)
+}
+
+// Example of generating a Telegram login widget.
+func ExampleProvider_GenerateWidget() {
+	provider := shieldtelegram.NewProvider(&shieldtelegram.Config{
+		BotToken: "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+	})
+
+	// Generate widget with custom options
+	radius := 10
+	widget := provider.GenerateWidget(
+		"https://example.com/auth/telegram/callback",
+		&shieldtelegram.WidgetOptions{
+			Size:          "large",
+			RequestAccess: true,
+			Radius:        &radius,
+			UsePic:        true,
+			Lang:          "en",
+		},
+	)
+
+	fmt.Printf("Widget HTML generated: %d bytes\n", len(widget))
+}
+
+// Example of a complete HTTP handler for Telegram login.
+func Example_httpHandler() {
+	provider := shieldtelegram.NewProvider(&shieldtelegram.Config{
+		BotToken:   "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+		MaxAuthAge: 1 * time.Hour,
+	})
+
+	// Login page handler
+	http.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+		widget := provider.GenerateWidget(
+			"https://example.com/auth/telegram/callback",
+			&shieldtelegram.WidgetOptions{
+				Size: "large",
+				Lang: "en",
+			},
+		)
+
+		fmt.Fprintf(w, `
+<!DOCTYPE html>
+<html>
+<head><title>Login with Telegram</title></head>
+<body>
+	<h1>Login with Telegram</h1>
+	%s
+	%s
+</body>
+</html>
+`, widget, shieldtelegram.GenerateWidgetCallback("https://example.com/api/auth/telegram"))
+	})
+
+	// Callback handler
+	http.HandleFunc("/api/auth/telegram", func(w http.ResponseWriter, r *http.Request) {
+		userInfo, err := shieldtelegram.HandleCallback(r.Context(), r, provider)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		// Create session, set cookies, etc.
+		fmt.Fprintf(w, `{"success": true, "user_id": %d, "username": "%s"}`,
+			userInfo.ID, userInfo.Username)
+	})
+
+	// In a real application, you would start the server here
+	// http.ListenAndServe(":8080", nil)
+}

--- a/shieldtelegram/handler.go
+++ b/shieldtelegram/handler.go
@@ -1,0 +1,108 @@
+package shieldtelegram
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// HandleCallback processes the Telegram login callback.
+//
+// Telegram sends authentication data as URL hash parameters (client-side).
+// This means the data needs to be extracted via JavaScript and sent to the server.
+// This handler expects the data to be submitted as either:
+// - URL query parameters (if forwarded from client-side)
+// - JSON in the request body
+func HandleCallback(
+	ctx context.Context,
+	r *http.Request,
+	provider Provider,
+) (*UserInfo, error) {
+	authData, err := parseAuthData(r)
+	if err != nil {
+		return nil, fmt.Errorf("shieldtelegram: failed to parse auth data: %w", err)
+	}
+
+	userInfo, err := provider.Verify(ctx, authData)
+	if err != nil {
+		return nil, fmt.Errorf("shieldtelegram: verification failed: %w", err)
+	}
+
+	return userInfo, nil
+}
+
+// parseAuthData extracts authentication data from the HTTP request.
+//
+// It tries to parse data from:
+// 1. URL query parameters (GET request)
+// 2. Form data (POST request)
+// 3. JSON body (POST request)
+func parseAuthData(r *http.Request) (*AuthData, error) {
+	var values url.Values
+
+	// Try to get data from URL query parameters first
+	if r.URL.Query().Get("id") != "" {
+		values = r.URL.Query()
+	} else if r.Method == http.MethodPost {
+		// Try to parse as JSON
+		if r.Header.Get("Content-Type") == "application/json" {
+			var authData AuthData
+			if err := json.NewDecoder(r.Body).Decode(&authData); err != nil {
+				return nil, fmt.Errorf("failed to decode JSON: %w", err)
+			}
+			return &authData, nil
+		}
+
+		// Try to parse as form data
+		if err := r.ParseForm(); err == nil && r.Form.Get("id") != "" {
+			values = r.Form
+		}
+	}
+
+	if values == nil {
+		return nil, ErrMissingAuthData
+	}
+
+	return parseValuesIntoAuthData(values)
+}
+
+// parseValuesIntoAuthData converts url.Values into AuthData struct.
+func parseValuesIntoAuthData(values url.Values) (*AuthData, error) {
+	idStr := values.Get("id")
+	if idStr == "" {
+		return nil, ErrMissingAuthData
+	}
+
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user ID: %w", err)
+	}
+
+	authDateStr := values.Get("auth_date")
+	if authDateStr == "" {
+		return nil, ErrMissingAuthData
+	}
+
+	authDate, err := strconv.ParseInt(authDateStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid auth_date: %w", err)
+	}
+
+	hash := values.Get("hash")
+	if hash == "" {
+		return nil, ErrMissingAuthData
+	}
+
+	return &AuthData{
+		ID:        id,
+		FirstName: values.Get("first_name"),
+		LastName:  values.Get("last_name"),
+		Username:  values.Get("username"),
+		PhotoURL:  values.Get("photo_url"),
+		AuthDate:  authDate,
+		Hash:      hash,
+	}, nil
+}

--- a/shieldtelegram/shieldtelegram.go
+++ b/shieldtelegram/shieldtelegram.go
@@ -1,0 +1,108 @@
+// Package shieldtelegram implements Telegram Bot Login authentication flow.
+//
+// Telegram Bot Login uses a widget-based authentication mechanism where users
+// authorize via the Telegram app and authentication data is returned as URL
+// hash parameters. This differs from standard OAuth2 flows.
+//
+// See: https://core.telegram.org/widgets/login
+package shieldtelegram
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"go.inout.gg/foundations/debug"
+)
+
+//nolint:gochecknoglobals
+var d = debug.Debuglog("shieldtelegram")
+
+var (
+	// ErrInvalidHash is returned when the authentication hash verification fails.
+	ErrInvalidHash = errors.New("shieldtelegram: invalid authentication hash")
+
+	// ErrAuthExpired is returned when the authentication data is too old.
+	ErrAuthExpired = errors.New("shieldtelegram: authentication data expired")
+
+	// ErrMissingAuthData is returned when required authentication data is missing.
+	ErrMissingAuthData = errors.New("shieldtelegram: missing required authentication data")
+)
+
+// AuthData represents the authentication data received from Telegram.
+//
+// This data is passed as URL hash parameters after successful authentication
+// via the Telegram Login Widget.
+type AuthData struct {
+	// ID is the unique Telegram user identifier.
+	ID int64 `json:"id"`
+
+	// FirstName is the user's first name.
+	FirstName string `json:"first_name"`
+
+	// LastName is the user's last name (optional).
+	LastName string `json:"last_name,omitempty"`
+
+	// Username is the user's Telegram username (optional).
+	Username string `json:"username,omitempty"`
+
+	// PhotoURL is the URL to the user's profile photo (optional).
+	PhotoURL string `json:"photo_url,omitempty"`
+
+	// AuthDate is the Unix timestamp when the authentication occurred.
+	AuthDate int64 `json:"auth_date"`
+
+	// Hash is the HMAC-SHA256 signature of the data using the bot token.
+	Hash string `json:"hash"`
+}
+
+// UserInfo contains the validated user information after successful authentication.
+type UserInfo struct {
+	ID        int64
+	FirstName string
+	LastName  string
+	Username  string
+	PhotoURL  string
+	AuthDate  time.Time
+}
+
+// Config holds the configuration for Telegram Bot Login.
+type Config struct {
+	// BotToken is the bot token obtained from BotFather.
+	BotToken string
+
+	// BotUsername is the bot's username (without @) for the login widget.
+	// This is required for generating the Telegram Login Widget.
+	BotUsername string
+
+	// MaxAuthAge is the maximum age of authentication data to accept.
+	// If zero, a default of 24 hours is used.
+	MaxAuthAge time.Duration
+}
+
+// Provider handles Telegram Bot Login authentication.
+type Provider interface {
+	// Verify validates the authentication data and returns user information.
+	Verify(ctx context.Context, data *AuthData) (*UserInfo, error)
+
+	// GenerateWidget returns HTML/JavaScript code for the Telegram Login Widget.
+	GenerateWidget(redirectURL string, opts *WidgetOptions) string
+}
+
+// WidgetOptions contains options for customizing the Telegram Login Widget.
+type WidgetOptions struct {
+	// Size of the widget button: "large", "medium", or "small".
+	Size string
+
+	// RequestAccess requests permission to message the user.
+	RequestAccess bool
+
+	// Radius sets the border radius of the button (0-20).
+	Radius *int
+
+	// UsePic displays the user's photo in the button.
+	UsePic bool
+
+	// Lang sets the widget language (default: "en").
+	Lang string
+}

--- a/shieldtelegram/validator.go
+++ b/shieldtelegram/validator.go
@@ -1,0 +1,133 @@
+package shieldtelegram
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var _ Provider = (*provider)(nil)
+
+type provider struct {
+	botToken    string
+	botUsername string
+	maxAuthAge  time.Duration
+}
+
+// NewProvider creates a new Telegram Login provider.
+func NewProvider(cfg *Config) Provider {
+	maxAuthAge := cfg.MaxAuthAge
+	if maxAuthAge == 0 {
+		maxAuthAge = 24 * time.Hour
+	}
+
+	return &provider{
+		botToken:    cfg.BotToken,
+		botUsername: cfg.BotUsername,
+		maxAuthAge:  maxAuthAge,
+	}
+}
+
+// Verify validates the Telegram authentication data using HMAC-SHA256.
+//
+// The verification process follows Telegram's specification:
+// 1. Create a data-check-string by concatenating key=value pairs (excluding hash)
+// 2. Calculate SHA256 hash of the bot token
+// 3. Calculate HMAC-SHA256 of the data-check-string using the token hash as key
+// 4. Compare the resulting hash with the provided hash
+//
+// See: https://core.telegram.org/widgets/login#checking-authorization
+func (p *provider) Verify(ctx context.Context, data *AuthData) (*UserInfo, error) {
+	if data == nil {
+		return nil, ErrMissingAuthData
+	}
+
+	if data.ID == 0 || data.AuthDate == 0 || data.Hash == "" {
+		return nil, ErrMissingAuthData
+	}
+
+	// Check if the authentication data is not too old
+	authTime := time.Unix(data.AuthDate, 0)
+	if time.Since(authTime) > p.maxAuthAge {
+		return nil, ErrAuthExpired
+	}
+
+	// Verify the hash
+	if !p.verifyHash(data) {
+		return nil, ErrInvalidHash
+	}
+
+	// Return validated user info
+	return &UserInfo{
+		ID:        data.ID,
+		FirstName: data.FirstName,
+		LastName:  data.LastName,
+		Username:  data.Username,
+		PhotoURL:  data.PhotoURL,
+		AuthDate:  authTime,
+	}, nil
+}
+
+// verifyHash validates the HMAC-SHA256 signature of the authentication data.
+func (p *provider) verifyHash(data *AuthData) bool {
+	// Build the data-check-string from all fields except hash
+	dataCheckString := p.buildDataCheckString(data)
+
+	// Calculate the secret key: SHA256 hash of the bot token
+	secretKey := sha256.Sum256([]byte(p.botToken))
+
+	// Calculate HMAC-SHA256 of the data-check-string
+	h := hmac.New(sha256.New, secretKey[:])
+	h.Write([]byte(dataCheckString))
+	calculatedHash := hex.EncodeToString(h.Sum(nil))
+
+	// Compare with the provided hash
+	return hmac.Equal([]byte(calculatedHash), []byte(data.Hash))
+}
+
+// buildDataCheckString creates the data-check-string from authentication data.
+//
+// The string is built by:
+// 1. Creating key=value pairs for all non-empty fields (excluding hash)
+// 2. Sorting the pairs alphabetically by key
+// 3. Joining them with newline characters
+func (p *provider) buildDataCheckString(data *AuthData) string {
+	var pairs []string
+
+	// Add all non-empty fields
+	if data.ID != 0 {
+		pairs = append(pairs, fmt.Sprintf("id=%d", data.ID))
+	}
+
+	if data.FirstName != "" {
+		pairs = append(pairs, fmt.Sprintf("first_name=%s", data.FirstName))
+	}
+
+	if data.LastName != "" {
+		pairs = append(pairs, fmt.Sprintf("last_name=%s", data.LastName))
+	}
+
+	if data.Username != "" {
+		pairs = append(pairs, fmt.Sprintf("username=%s", data.Username))
+	}
+
+	if data.PhotoURL != "" {
+		pairs = append(pairs, fmt.Sprintf("photo_url=%s", data.PhotoURL))
+	}
+
+	if data.AuthDate != 0 {
+		pairs = append(pairs, fmt.Sprintf("auth_date=%s", strconv.FormatInt(data.AuthDate, 10)))
+	}
+
+	// Sort alphabetically
+	sort.Strings(pairs)
+
+	// Join with newlines
+	return strings.Join(pairs, "\n")
+}

--- a/shieldtelegram/validator_test.go
+++ b/shieldtelegram/validator_test.go
@@ -1,0 +1,170 @@
+package shieldtelegram
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+func TestVerify_ValidData(t *testing.T) {
+	botToken := "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	provider := NewProvider(&Config{
+		BotToken:    botToken,
+		BotUsername: "test_bot",
+		MaxAuthAge:  24 * time.Hour,
+	})
+
+	// Create valid auth data with a proper hash
+	authDate := time.Now().Unix()
+	authData := &AuthData{
+		ID:        123456789,
+		FirstName: "John",
+		LastName:  "Doe",
+		Username:  "johndoe",
+		AuthDate:  authDate,
+	}
+
+	// Calculate the correct hash
+	authData.Hash = calculateHash(botToken, authData)
+
+	// Verify the data
+	userInfo, err := provider.Verify(context.Background(), authData)
+	if err != nil {
+		t.Fatalf("Expected valid auth data to verify, got error: %v", err)
+	}
+
+	if userInfo.ID != authData.ID {
+		t.Errorf("Expected ID %d, got %d", authData.ID, userInfo.ID)
+	}
+
+	if userInfo.FirstName != authData.FirstName {
+		t.Errorf("Expected FirstName %s, got %s", authData.FirstName, userInfo.FirstName)
+	}
+}
+
+func TestVerify_InvalidHash(t *testing.T) {
+	provider := NewProvider(&Config{
+		BotToken:    "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		BotUsername: "test_bot",
+		MaxAuthAge:  24 * time.Hour,
+	})
+
+	authData := &AuthData{
+		ID:        123456789,
+		FirstName: "John",
+		AuthDate:  time.Now().Unix(),
+		Hash:      "invalid_hash",
+	}
+
+	_, err := provider.Verify(context.Background(), authData)
+	if err != ErrInvalidHash {
+		t.Errorf("Expected ErrInvalidHash, got %v", err)
+	}
+}
+
+func TestVerify_ExpiredAuth(t *testing.T) {
+	provider := NewProvider(&Config{
+		BotToken:    "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		BotUsername: "test_bot",
+		MaxAuthAge:  1 * time.Hour,
+	})
+
+	// Create auth data from 2 hours ago
+	authDate := time.Now().Add(-2 * time.Hour).Unix()
+	authData := &AuthData{
+		ID:        123456789,
+		FirstName: "John",
+		AuthDate:  authDate,
+		Hash:      "some_hash",
+	}
+
+	_, err := provider.Verify(context.Background(), authData)
+	if err != ErrAuthExpired {
+		t.Errorf("Expected ErrAuthExpired, got %v", err)
+	}
+}
+
+func TestVerify_MissingData(t *testing.T) {
+	provider := NewProvider(&Config{
+		BotToken:    "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		BotUsername: "test_bot",
+	})
+
+	tests := []struct {
+		name string
+		data *AuthData
+	}{
+		{
+			name: "nil data",
+			data: nil,
+		},
+		{
+			name: "missing ID",
+			data: &AuthData{
+				FirstName: "John",
+				AuthDate:  time.Now().Unix(),
+				Hash:      "hash",
+			},
+		},
+		{
+			name: "missing auth_date",
+			data: &AuthData{
+				ID:        123456789,
+				FirstName: "John",
+				Hash:      "hash",
+			},
+		},
+		{
+			name: "missing hash",
+			data: &AuthData{
+				ID:        123456789,
+				FirstName: "John",
+				AuthDate:  time.Now().Unix(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := provider.Verify(context.Background(), tt.data)
+			if err != ErrMissingAuthData {
+				t.Errorf("Expected ErrMissingAuthData, got %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildDataCheckString(t *testing.T) {
+	p := &provider{}
+
+	authData := &AuthData{
+		ID:        123456789,
+		FirstName: "John",
+		LastName:  "Doe",
+		Username:  "johndoe",
+		PhotoURL:  "https://example.com/photo.jpg",
+		AuthDate:  1234567890,
+	}
+
+	dataCheckString := p.buildDataCheckString(authData)
+
+	// The string should be sorted alphabetically
+	expected := "auth_date=1234567890\nfirst_name=John\nid=123456789\nlast_name=Doe\nphoto_url=https://example.com/photo.jpg\nusername=johndoe"
+
+	if dataCheckString != expected {
+		t.Errorf("Expected:\n%s\n\nGot:\n%s", expected, dataCheckString)
+	}
+}
+
+// Helper function to calculate a valid hash for testing
+func calculateHash(botToken string, data *AuthData) string {
+	p := &provider{botToken: botToken}
+	dataCheckString := p.buildDataCheckString(data)
+	secretKey := sha256.Sum256([]byte(botToken))
+	h := hmac.New(sha256.New, secretKey[:])
+	h.Write([]byte(dataCheckString))
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/shieldtelegram/widget.go
+++ b/shieldtelegram/widget.go
@@ -1,0 +1,135 @@
+package shieldtelegram
+
+import (
+	"fmt"
+	"html/template"
+	"strconv"
+	"strings"
+)
+
+// GenerateWidget generates HTML/JavaScript code for the Telegram Login Widget.
+//
+// The widget can be embedded in a web page to allow users to authenticate
+// using their Telegram account. When the user clicks the button, they will
+// be redirected to Telegram for authentication, and then back to the redirectURL
+// with authentication data in the URL hash.
+//
+// See: https://core.telegram.org/widgets/login
+func (p *provider) GenerateWidget(redirectURL string, opts *WidgetOptions) string {
+	if opts == nil {
+		opts = &WidgetOptions{
+			Size: "large",
+			Lang: "en",
+		}
+	}
+
+	// Build widget attributes
+	attrs := p.buildWidgetAttributes(redirectURL, opts)
+
+	// Generate the widget HTML
+	return fmt.Sprintf(`<script async src="https://telegram.org/js/telegram-widget.js?22" data-telegram-login="%s"%s></script>`,
+		template.HTMLEscapeString(p.botUsername),
+		attrs,
+	)
+}
+
+// buildWidgetAttributes builds the HTML attributes for the Telegram widget script tag.
+func (p *provider) buildWidgetAttributes(redirectURL string, opts *WidgetOptions) string {
+	var attrs []string
+
+	// Add redirect URL (auth-url attribute)
+	attrs = append(attrs, fmt.Sprintf(` data-auth-url="%s"`, template.HTMLEscapeString(redirectURL)))
+
+	// Add size
+	if opts.Size != "" {
+		attrs = append(attrs, fmt.Sprintf(` data-size="%s"`, template.HTMLEscapeString(opts.Size)))
+	}
+
+	// Add request-access
+	if opts.RequestAccess {
+		attrs = append(attrs, ` data-request-access="write"`)
+	}
+
+	// Add radius
+	if opts.Radius != nil {
+		radius := *opts.Radius
+		if radius < 0 {
+			radius = 0
+		}
+		if radius > 20 {
+			radius = 20
+		}
+		attrs = append(attrs, fmt.Sprintf(` data-radius="%s"`, strconv.Itoa(radius)))
+	}
+
+	// Add userpic
+	if opts.UsePic {
+		attrs = append(attrs, ` data-userpic="true"`)
+	}
+
+	// Add language
+	if opts.Lang != "" && opts.Lang != "en" {
+		attrs = append(attrs, fmt.Sprintf(` data-lang="%s"`, template.HTMLEscapeString(opts.Lang)))
+	}
+
+	return strings.Join(attrs, "")
+}
+
+// GenerateWidgetCallback generates JavaScript code to handle the widget callback.
+//
+// This code should be included on the page that will receive the callback.
+// It extracts the authentication data from the URL hash and sends it to your server.
+func GenerateWidgetCallback(serverCallbackURL string) string {
+	return fmt.Sprintf(`
+<script>
+(function() {
+	// Parse authentication data from URL hash
+	function getTelegramAuthData() {
+		const hash = window.location.hash.substring(1);
+		if (!hash) return null;
+
+		const params = new URLSearchParams(hash);
+		const data = {};
+
+		for (const [key, value] of params) {
+			if (key.startsWith('tgAuthResult')) {
+				// Telegram wraps the data in tgAuthResult
+				try {
+					return JSON.parse(decodeURIComponent(value));
+				} catch (e) {
+					console.error('Failed to parse Telegram auth data:', e);
+					return null;
+				}
+			}
+			// Also support direct parameter format
+			data[key] = value;
+		}
+
+		return Object.keys(data).length > 0 ? data : null;
+	}
+
+	// Send auth data to server
+	const authData = getTelegramAuthData();
+	if (authData) {
+		fetch(%q, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify(authData)
+		})
+		.then(response => response.json())
+		.then(data => {
+			console.log('Authentication successful:', data);
+			// Handle successful authentication
+			// Redirect or update UI as needed
+		})
+		.catch(error => {
+			console.error('Authentication failed:', error);
+			// Handle authentication failure
+		});
+	}
+})();
+</script>
+`, serverCallbackURL)
+}


### PR DESCRIPTION
Implements Telegram Bot Login authentication flow as a separate module.

Features:
- HMAC-SHA256 signature verification according to Telegram spec
- Telegram Login Widget generation with customizable options
- HTTP handler for processing authentication callbacks
- Configurable authentication data age validation
- Support for multiple input formats (query params, form, JSON)

The implementation follows Shield's modular architecture and provides
a non-OAuth2 authentication method that complements existing SSO providers.

Files:
- shieldtelegram.go: Core types and interfaces
- validator.go: HMAC-SHA256 verification logic
- handler.go: HTTP callback handler
- widget.go: Login widget HTML/JS generation
- validator_test.go: Unit tests
- example_test.go: Usage examples
- README.md: Complete documentation